### PR TITLE
Request notification permission on Android 13+

### DIFF
--- a/app/src/main/java/cse489/project/doctorsappointmentapp/Homepage.java
+++ b/app/src/main/java/cse489/project/doctorsappointmentapp/Homepage.java
@@ -4,7 +4,11 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
@@ -34,6 +38,7 @@ import java.util.List;
 import java.util.Locale;
 
 public class Homepage extends AppCompatActivity {
+    private static final int NOTIFICATION_PERMISSION_REQUEST_CODE = 100;
     private TextView empty, Name;
     private ImageView home, appointmentBtn, history, Logout, userAvatar;
     private FirebaseAuth auth;
@@ -54,6 +59,7 @@ public class Homepage extends AppCompatActivity {
         db = FirebaseFirestore.getInstance();
         user = auth.getCurrentUser();
 
+        requestNotificationPermission();
         // Check user authentication
         checkUserAuthentication();
 
@@ -66,7 +72,28 @@ public class Homepage extends AppCompatActivity {
         // Handle navigation and button clicks
         handleNavigationClicks();
     }
+    private void requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) { // Android 13+
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+                    != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this,
+                        new String[]{Manifest.permission.POST_NOTIFICATIONS},
+                        NOTIFICATION_PERMISSION_REQUEST_CODE);
+            }
+        }
+    }
 
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                Toast.makeText(this, "Notification permission granted", Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, "Notification permission denied", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
     private void initializeViews() {
         Name = findViewById(R.id.name);
         Logout = findViewById(R.id.logout);


### PR DESCRIPTION
This commit adds a function to request the `POST_NOTIFICATIONS` permission for push notifications on devices running Android 13 or higher. This is done by:
1. Adding a new permission request function `requestNotificationPermission`.
2. Requesting the `POST_NOTIFICATIONS` permission at runtime.
3. Handling the user's permission response, displaying messages for granted or denied.
4. defining  `NOTIFICATION_PERMISSION_REQUEST_CODE` as a request code.